### PR TITLE
Better Linux support, venv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,34 @@ Start off by cloning or downloading the files in this repo.
 
 ### Setting up Python
 
-Install Python 3.10 or higher.
+Install Python 3.10 or higher ([download page](https://www.python.org/downloads/)).
 
-Install required packages with `pip install -r requirements.txt`.
+Move to this directory in your shell and install required packages with `pip install -r requirements.txt` (or set up a virtual environment first; see below).
+
+#### Using a venv (optional)
+
+Setting up a Python virtual environment (venv) before installing the dependencies is recommended on Linux,
+but also if you are using Python for many things on your system.
+
+If you use a venv, remember to do the activate step before running the `trade.py` script.
+
+The easiest way to get started:
+
+```powershell
+# Windows (cmd)
+python -m venv venv
+venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+```sh
+# Linux (bash/zsh)
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Refer to the [official documentation](https://docs.python.org/3/library/venv.html) for other options and more details.
 
 ### Setting up adb (Android Debug Bridge)
 

--- a/trade.py
+++ b/trade.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 AutoTrader, a script for automating trading in Pokémon GO on Android.
 Author: jonaro00


### PR DESCRIPTION
Closes #5

- venv instructions
- modified the file permissions and hashbang so that the script will successfully run with `./trade.py` on Linux regardless of venv
